### PR TITLE
Darkmode Button Header로 이동

### DIFF
--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -7,4 +7,12 @@ module.exports = {
     "react/no-unknown-property": ["error", { ignore: ["css"] }],
     "@typescript-eslint/no-unused-vars": "warn",
   },
+  overrides: [
+    {
+      files: ["jest.setup.js"],
+      rules: {
+        "no-undef": "off",
+      },
+    },
+  ],
 };

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -1,1 +1,28 @@
+import "@testing-library/jest-dom";
 import "@testing-library/jest-dom/extend-expect";
+
+class LocalStorageMock {
+  constructor() {
+    this.store = {};
+  }
+
+  getItem(key) {
+    return this.store[key] || null;
+  }
+
+  setItem(key, value) {
+    this.store[key] = String(value);
+  }
+}
+
+global.localStorage = new LocalStorageMock();
+
+const originalError = console.error;
+
+global.console.error = jest.fn((...args) => {
+  if (typeof args[0] === "string" && args[0].includes("should be wrapped into act")) {
+    return;
+  }
+
+  return originalError.call(console, args);
+});

--- a/app/src/components/ui/atoms/MenuItem/index.tsx
+++ b/app/src/components/ui/atoms/MenuItem/index.tsx
@@ -27,7 +27,8 @@ const Li = styled.li`
 
   cursor: pointer;
 
-  & > a {
+  & > a,
+  &:not(:has(a)) {
     width: 100%;
     padding: 0.7rem 0.5rem;
   }

--- a/app/src/components/ui/molecules/DarkModeButton/index.tsx
+++ b/app/src/components/ui/molecules/DarkModeButton/index.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
+import { getTransitionEffect } from "@seoko/theme";
 import styled from "@emotion/styled";
 
-import { getTransitionEffect } from "@utils/css/getTransitionEffect";
 import useDarkMode from "@hooks/useDarkMode";
 
 import SunIcon from "@components/icons/SunIcon";
@@ -13,7 +13,7 @@ const DarkModeButton = () => {
 
   if (!mode) return null;
 
-  const Icon = mode === "light" ? SunIcon : MoonIcon;
+  const Icon = mode === "light" ? MoonIcon : SunIcon;
 
   return (
     <Container onClick={onChangeTheme}>
@@ -26,41 +26,26 @@ const Container = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  position: fixed;
-
-  right: 30px;
-  bottom: 30px;
-
-  width: 40px;
-  height: 40px;
 
   z-index: 50;
   cursor: pointer;
 
-  background-color: ${({ theme }) => theme.background4};
-  box-shadow: ${({ theme }) => theme.BOX_SHADOW.primary};
-
   border: 0;
-  border-radius: 50%;
-
   padding: 0;
+
+  background-color: transparent;
 
   & > svg {
     width: 24px;
     height: 24px;
-    fill: #ccc;
-    transition: fill 0.3s;
-  }
+    fill: ${({ theme }) => theme.grey500};
 
-  &:hover {
-    transform: scale(1.1);
-    box-shadow: ${({ theme }) => theme.BOX_SHADOW.primary};
-    & > svg {
+    ${getTransitionEffect("fill")}
+
+    &:hover {
       fill: #ffd500;
     }
   }
-
-  ${getTransitionEffect(["background-color", "transform"], 300)}
 `;
 
 export default DarkModeButton;

--- a/app/src/components/ui/molecules/Menu/User/index.tsx
+++ b/app/src/components/ui/molecules/Menu/User/index.tsx
@@ -21,7 +21,7 @@ const Menu: React.FC<IProps> = ({ username }) => {
     button: (
       <AvatarWrapper>
         <Avatar />
-        <span>지석호</span>
+        <span>{username}</span>
       </AvatarWrapper>
     ),
     menu: <UserMenu {...userMenuProps} />,

--- a/app/src/components/ui/organisms/Header/Nav.tsx
+++ b/app/src/components/ui/organisms/Header/Nav.tsx
@@ -4,6 +4,7 @@ import styled from "@emotion/styled";
 
 import UserMenu from "@components/ui/molecules/Menu/User";
 import PageMenu from "@components/ui/molecules/Menu/Page";
+import DarkModeButton from "@components/ui/molecules/DarkModeButton";
 
 const Nav = () => {
   const username = null;
@@ -14,6 +15,7 @@ const Nav = () => {
 
   return (
     <Container>
+      <DarkModeButton />
       {username && <UserMenu {...menuProps} />}
       <PageMenu {...menuProps} />
     </Container>

--- a/app/src/hooks/useDarkMode.ts
+++ b/app/src/hooks/useDarkMode.ts
@@ -12,7 +12,22 @@ const useDarkMode: TResult = () => {
 
     const theme = localStorage.getItem("theme") as TDarkMode;
 
-    setMode(theme);
+    if (theme) setMode(theme);
+
+    const storageListener = (e: StorageEvent) => {
+      if (e.key !== "theme") return;
+
+      const theme = e.newValue as TDarkMode;
+
+      bodyRef.current.dataset.theme = theme;
+      setMode(theme);
+    };
+
+    window.addEventListener("storage", storageListener);
+
+    return () => {
+      window.removeEventListener("storage", storageListener);
+    };
   }, []);
 
   const onChangeTheme = useCallback(() => {
@@ -21,9 +36,7 @@ const useDarkMode: TResult = () => {
     const theme = mode === "light" ? "dark" : "light";
 
     bodyRef.current.dataset.theme = theme;
-
     localStorage.setItem("theme", theme);
-
     setMode(theme);
   }, [mode]);
 

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -10,7 +10,6 @@ import { ApolloProvider } from "@apollo/client";
 
 import AppLayout from "@components/ui/templates/AppLayout";
 import Header from "@components/ui/organisms/Header";
-import DarkModeButton from "@components/ui/molecules/DarkModeButton";
 import { useApollo } from "@ap/useApollo";
 
 const notoSansKr = Noto_Sans_KR({
@@ -28,7 +27,6 @@ const SEOKO = ({ Component, pageProps }: AppProps) => {
         <AppLayout className={notoSansKr.className}>
           <Header />
           <Component {...pageProps} />
-          <DarkModeButton />
         </AppLayout>
       </ThemeProvider>
     </ApolloProvider>

--- a/app/tests/components/DarkmodeButton.test.tsx
+++ b/app/tests/components/DarkmodeButton.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
-import { act, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 
 import DarkModeButton from "@components/ui/molecules/DarkModeButton";
 
@@ -19,9 +19,7 @@ describe("DarkModeButton", () => {
   it("버튼 랜더링 테스트", () => {
     const { container: app } = render(<DarkModeButton />);
 
-    const icon = app.querySelector("svg");
-
-    expect(icon).toBeInTheDocument();
+    expect(app).toBeInTheDocument();
   });
 
   it("버튼 클릭 테스트", async () => {
@@ -31,17 +29,15 @@ describe("DarkModeButton", () => {
 
     let icon = app.querySelector("svg") as unknown as HTMLElement;
 
-    expect(icon.id).toContain("sun-icon");
+    expect(icon.id).toContain("moon-icon");
 
-    await act(() => {
-      return userEvent.click(button);
-    });
+    await userEvent.click(button);
 
     rerender(<DarkModeButton />);
 
     icon = app.querySelector("svg") as unknown as HTMLElement;
 
-    expect(icon.id).toContain("moon-icon");
+    expect(icon.id).toContain("sun-icon");
   });
 
   it("mode가 null일 때 테스트", () => {

--- a/app/tests/components/Menu.test.tsx
+++ b/app/tests/components/Menu.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import "@testing-library/jest-dom";
+import PageMenu from "@components/ui/molecules/Menu/Page/List";
+
+import { render } from "../utils/theme";
+
+describe("Menu", () => {
+  it("메뉴 랜더링 테스트", () => {
+    const { container: app } = render(<PageMenu isSign={true} />);
+
+    expect(app).toBeInTheDocument();
+  });
+
+  it("메뉴 로그인 시", async () => {
+    const { getAllByRole } = render(<PageMenu isSign={true} />);
+
+    const list = getAllByRole("listitem");
+
+    expect(list).toHaveLength(3);
+    expect(list[list.length - 1]).not.toHaveTextContent(/로그인/gi);
+  });
+
+  it("메뉴 로그아웃 시", async () => {
+    const { getAllByRole } = render(<PageMenu isSign={false} />);
+
+    const list = getAllByRole("listitem");
+
+    expect(list).toHaveLength(4);
+    expect(list[list.length - 1]).toHaveTextContent(/로그인/gi);
+  });
+});


### PR DESCRIPTION
## ✨ **구현 기능 명세**
- 기존 화면 좌측 하단에 존재하던 Darkmode button을 헤더로 이동합니다.

## 🌄 **스크린샷**
![화면 기록 2023-07-11 오전 12 47 40](https://github.com/seoko97/SEOKO-client/assets/60173534/cd1b8d73-6bdc-4152-8b6b-657052a3e3b1)
