### PR TITLE
시리즈 페이지 구현

### DIFF
--- a/src/apis/series.ts
+++ b/src/apis/series.ts
@@ -1,4 +1,4 @@
-import { ISeries } from "@/types";
+import { ISeries, IUpdateSeriesInput } from "@/types";
 import api from "@/apis";
 
 const getSeriesAll = async () => {
@@ -7,4 +7,22 @@ const getSeriesAll = async () => {
   return data;
 };
 
-export { getSeriesAll };
+const getSeries = async (nid: number) => {
+  const { data } = await api.get<ISeries>(`/series/${nid}`);
+
+  return data;
+};
+
+const updateSeries = async (nid: number, body: IUpdateSeriesInput) => {
+  const { data } = await api.put<ISeries>(`/series/${nid}`, body);
+
+  return data;
+};
+
+const deleteSeries = async (nid: number) => {
+  const { data } = await api.delete<ISeries>(`/series/${nid}`);
+
+  return data;
+};
+
+export { getSeriesAll, getSeries, updateSeries, deleteSeries };

--- a/src/app/series/[nid]/page.ts
+++ b/src/app/series/[nid]/page.ts
@@ -1,0 +1,1 @@
+export { default } from "@components/pages/Series/[nid]";

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -74,6 +74,17 @@ const ICONS = {
       <path d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"></path>
     </svg>
   ),
+  ChevronIcon: (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+    </svg>
+  ),
   SunIcon: (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" x="0px" y="0px" id="sun-icon">
       <circle cx="12" cy="12" r="6" />
@@ -127,6 +138,7 @@ export const {
   MoonIcon,
   ReftArrowIcon,
   RightArrowIcon,
+  ChevronIcon,
   SearchIcon,
   SunIcon,
   ViewIcon,

--- a/src/components/modal/series/edit.tsx
+++ b/src/components/modal/series/edit.tsx
@@ -1,0 +1,92 @@
+import React, { useRef } from "react";
+
+import useInput from "@hooks/useInput";
+import { useUpdateSeriesMutation } from "@hooks/query/series";
+import { useUploadImage } from "@hooks/query/image";
+import Input from "@components/ui/core/Input";
+import Image from "@components/ui/core/Image";
+import Button from "@components/ui/core/Button";
+import ModalLayout from "@components/modal/ModalLayout";
+import { ImageIcon } from "@components/icons";
+import { ISeries } from "@/types";
+
+interface IProps {
+  series: ISeries;
+  onClose: () => void;
+}
+
+const EditSeries = ({ series, onClose }: IProps) => {
+  const thumbnailRef = useRef<HTMLInputElement>(null);
+
+  const { name, thumbnail, nid } = series;
+
+  const { mutate: updateSeries } = useUpdateSeriesMutation(nid);
+  const [input, onChangeInput] = useInput({ name });
+
+  const { image, changeImage, clearImage } = useUploadImage({
+    defaultImg: thumbnail,
+    type: "series",
+  });
+
+  const thumbnailHandler = (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    thumbnailRef.current?.click();
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const confirmUpdate = confirm("수정하시겠습니까?");
+
+    if (!confirmUpdate) return;
+
+    updateSeries({ ...input, thumbnail: image });
+    onClose();
+  };
+
+  return (
+    <ModalLayout onClose={onClose}>
+      <form
+        onSubmit={onSubmit}
+        className="z-[60] flex h-fit max-h-[600px] w-[600px] flex-col gap-4 rounded-md bg-tertiary px-5 py-7 shadow-md transition-[background-color] md:w-full"
+      >
+        <div className="flex w-full items-center gap-2">
+          <h3 className="text-lg font-semibold text-primary">시리즈 이름</h3>
+          <Input
+            name="name"
+            defaultValue={name}
+            placeholder="시리즈 이름을 입력하세요"
+            onChange={onChangeInput}
+          />
+        </div>
+        <h3 className="text-xl font-semibold text-primary">썸네일</h3>
+        <div className="flex items-center gap-4">
+          <div className="w-[200px] cursor-pointer md:w-full">
+            {image && <Image src={image} alt="thumbnail" onClick={clearImage} />}
+          </div>
+          <span onClick={thumbnailHandler}>
+            <ImageIcon className="h-16 w-16 cursor-pointer fill-[theme(textColor.primary)] hover:opacity-50" />
+          </span>
+          <input
+            type="file"
+            accept="image/jpg, image/jpeg, image/png"
+            ref={thumbnailRef}
+            style={{ display: "none" }}
+            onChange={changeImage}
+          />
+        </div>
+        <div className="flex gap-4 [&>button]:flex-1">
+          <Button type="button" buttonType="danger" onClick={onClose}>
+            취소
+          </Button>
+          <Button type="submit" buttonType="primary">
+            확인
+          </Button>
+        </div>
+      </form>
+    </ModalLayout>
+  );
+};
+
+export default EditSeries;

--- a/src/components/modal/series/edit.tsx
+++ b/src/components/modal/series/edit.tsx
@@ -51,12 +51,13 @@ const EditSeries = ({ series, onClose }: IProps) => {
         onSubmit={onSubmit}
         className="z-[60] flex h-fit max-h-[600px] w-[600px] flex-col gap-4 rounded-md bg-tertiary px-5 py-7 shadow-md transition-[background-color] md:w-full"
       >
-        <div className="flex w-full items-center gap-2">
+        <div className="flex w-full flex-col gap-4">
           <h3 className="text-lg font-semibold text-primary">시리즈 이름</h3>
           <Input
             name="name"
             defaultValue={name}
             placeholder="시리즈 이름을 입력하세요"
+            className="w-auto flex-1"
             onChange={onChangeInput}
           />
         </div>

--- a/src/components/modal/series/list.tsx
+++ b/src/components/modal/series/list.tsx
@@ -52,7 +52,6 @@ const SeriesList = (props: IProps) => {
             </li>
           ))}
         </ul>
-        {/* 버튼 */}
         <div className="flex gap-4 [&>button]:flex-1">
           <Button type="button" buttonType="danger" onClick={onClose}>
             취소

--- a/src/components/modal/series/list.tsx
+++ b/src/components/modal/series/list.tsx
@@ -38,13 +38,13 @@ const SeriesList = (props: IProps) => {
         className="z-[60] flex h-fit max-h-[600px] w-[600px] flex-col gap-4 rounded-md bg-tertiary px-5 py-7 shadow-md transition-[background-color] md:w-full"
       >
         <Input value={selectedSeries} onChange={onChangeValue} />
-        <ul className="flex flex-col">
+        <ul className="flex flex-col text-primary transition-colors">
           {series?.length === 0 && <h3>시리즈가 없습니다.</h3>}
           {series?.map((item) => (
             <li
               key={item._id + String(Math.random())}
               onClick={() => setSeries(item.name)}
-              className={`border-primary/50 flex-1 cursor-pointer border-t px-1 py-2 text-primary transition-colors first:border-none hover:text-effect1 ${
+              className={`border-primary/50 flex-1 cursor-pointer border-t px-1 py-2 first:border-none hover:text-effect1 ${
                 defaultSeries === item.name && "text-green-500"
               }}`}
             >

--- a/src/components/pages/Series/Hydrate.tsx
+++ b/src/components/pages/Series/Hydrate.tsx
@@ -21,7 +21,7 @@ const Hydrate = async ({ children }: IProps) => {
   return (
     <RqHydrate state={dehydratedState}>
       <div className="w-[theme(screens.md.max)] px-0 py-4 sm:mb-4 md:w-full">
-        <h1 className="mb-1 text-4xl font-bold text-primary transition-[color]">
+        <h1 className="mb-2 text-4xl font-bold text-primary transition-[color]">
           SERIES
           <span className="ml-4 align-top text-sm font-normal">{series.length} series</span>
         </h1>

--- a/src/components/pages/Series/[nid]/Hydrate.tsx
+++ b/src/components/pages/Series/[nid]/Hydrate.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import { notFound } from "next/navigation";
+
+import getQueryClient from "@utils/query/getQueryClient";
+import { Hydrate as RqHydrate, dehydrate } from "@tanstack/react-query";
+import { getSeries } from "@/apis/series";
+import { getPosts } from "@/apis/post";
+
+interface IProps {
+  nid: number;
+  children: React.ReactNode;
+}
+
+const Hydrate = async ({ nid, children }: IProps) => {
+  const queryClient = getQueryClient();
+
+  if (isNaN(nid)) return notFound();
+
+  try {
+    const series = await queryClient.fetchQuery({
+      queryKey: ["series", nid],
+      queryFn: () => getSeries(nid),
+    });
+
+    if (!series) return notFound();
+
+    const params = { series: series._id, sort: -1 };
+
+    await queryClient.prefetchInfiniteQuery({
+      queryKey: ["posts", params],
+      queryFn: () => getPosts(params),
+    });
+  } catch (error) {
+    return notFound();
+  }
+
+  const dehydratedState = dehydrate(queryClient);
+
+  return <RqHydrate state={dehydratedState}>{children}</RqHydrate>;
+};
+
+export default Hydrate;

--- a/src/components/pages/Series/[nid]/index.tsx
+++ b/src/components/pages/Series/[nid]/index.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import SeriesClient from "@components/pages/Series/[nid]/page.client";
+import Hydrate from "@components/pages/Series/[nid]/Hydrate";
+
+interface IProps {
+  params: {
+    nid: number;
+  };
+}
+
+const Series = ({ params }: IProps) => {
+  const nid = Number(params.nid);
+
+  return (
+    <section className="frame mb-8 flex flex-col items-center gap-4">
+      <Hydrate nid={nid}>
+        <SeriesClient nid={nid} />
+      </Hydrate>
+    </section>
+  );
+};
+
+export default Series;

--- a/src/components/pages/Series/[nid]/page.client.tsx
+++ b/src/components/pages/Series/[nid]/page.client.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, { useRef, useState } from "react";
+
+import { dateTimeParser } from "@utils/dateTimeParser";
+import { useGetUserQuery } from "@hooks/query/user";
+import { useDeleteSeriesMutation, useGetSeriesQuery } from "@hooks/query/series";
+import { useGetPostsQuery } from "@hooks/query/post";
+import PostList from "@components/ui/PostList";
+import Navigation from "@components/ui/Navigation";
+import EditSeries from "@components/modal/series/edit";
+import { ChevronIcon } from "@components/icons";
+
+interface IProps {
+  nid: number;
+}
+
+const SeriesClient = ({ nid }: IProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const [openModal, setOpenModal] = useState(false);
+  const [sort, setSort] = useState<1 | -1>(-1);
+
+  const { data: username } = useGetUserQuery();
+  const { data: series } = useGetSeriesQuery(nid);
+  const { mutate: deleteSeries } = useDeleteSeriesMutation(nid);
+
+  const [posts, fetchMorePosts] = useGetPostsQuery({ series: series?._id, sort });
+
+  const onClickSortButton = () => {
+    setSort((prev) => (prev === 1 ? -1 : 1));
+  };
+
+  const onDelete = () => {
+    const isDelete = confirm("시리즈를 삭제하시겠습니까?");
+
+    if (!isDelete) return;
+
+    deleteSeries();
+  };
+
+  const onEdit = () => {
+    setOpenModal(true);
+  };
+
+  if (!series) return null;
+
+  const { name, postCount, updatedAt } = series;
+
+  return (
+    <>
+      <div className="flex w-[theme(screens.md.max)] flex-col gap-2 px-0 py-4 text-primary transition-[color] sm:mb-4 md:w-full">
+        <h3 className="ml-1 text-lg font-bold text-main">SERIES</h3>
+        <h1 className="text-4xl font-bold">{name}</h1>
+        <div className="ml-1 truncate text-sm text-primary text-slate-500 dark:text-slate-400">
+          <span className="text-primary transition-[color]">{postCount}개의 포스트</span>
+          <span className="mx-1">·</span>
+          <span>마지막 업데이트 {dateTimeParser(updatedAt)}</span>
+        </div>
+      </div>
+      <div className="flex w-full flex-col gap-5">
+        <div className="flex flex-col items-end justify-center gap-4">
+          {username && <Navigation onEdit={onEdit} onDelete={onDelete} />}
+          <button
+            className="inline-flex items-center gap-2 rounded-md bg-slate-200 p-2 shadow-sm transition-[background-color] dark:bg-slate-700"
+            onClick={onClickSortButton}
+          >
+            <ChevronIcon
+              className={`h-4 w-4 stroke-[theme(textColor.main)] transition-[stroke,transform] ${
+                sort === -1 ? "rotate-180" : ""
+              }`}
+              strokeWidth={3.5}
+            />
+            <span className="text-primary transition-[color]">
+              {sort === -1 ? "내림차순" : "오름차순"}
+            </span>
+          </button>
+        </div>
+        {posts.length > 0 && <PostList ref={ref} posts={posts} func={fetchMorePosts} />}
+        {posts?.length === 0 && (
+          <div className="py-10 text-center text-2xl font-bold text-gray-400 sm:text-xl">
+            포스트를 찾을 수 없습니다 🙄
+          </div>
+        )}
+      </div>
+      {openModal && <EditSeries onClose={() => setOpenModal(false)} series={series} />}
+    </>
+  );
+};
+
+export default SeriesClient;

--- a/src/components/pages/Series/page.client.tsx
+++ b/src/components/pages/Series/page.client.tsx
@@ -19,14 +19,16 @@ const Series = () => {
         <Link key={series._id} href={`/series/${series.nid}`}>
           <div
             key={series._id}
-            className="flex cursor-pointer flex-col items-center justify-start gap-3 text-primary transition-[color]"
+            className="group flex cursor-pointer flex-col items-center justify-start gap-3"
           >
             <div className="w-full flex-1 rounded-b-md rounded-t-md">
               <Image src={series.thumbnail ?? "/main.jpg"} alt={series.name} priority />
             </div>
             <div className="flex w-full flex-col gap-2">
-              <h3 className="truncate text-base font-semibold">{series.name}</h3>
-              <div className="truncate text-sm text-primary text-slate-500">
+              <h3 className="truncate font-semibold text-primary transition-[color] group-hover:text-effect1">
+                {series.name}
+              </h3>
+              <div className="truncate text-sm text-slate-500 dark:text-slate-400">
                 <span className="text-primary transition-[color]">
                   {series.postCount}개의 포스트
                 </span>

--- a/src/components/ui/Markdown/overrides/code/index.tsx
+++ b/src/components/ui/Markdown/overrides/code/index.tsx
@@ -14,7 +14,7 @@ const code = ({ children, className = "", ...props }: IProps) => {
   return language ? (
     <SyntaxHighlighter
       language={language}
-      showLineNumbers={true}
+      showLineNumbers={language !== "txt"}
       startingLineNumber={1}
       codeTagProps={{
         className:

--- a/src/hooks/query/post.ts
+++ b/src/hooks/query/post.ts
@@ -81,10 +81,12 @@ const useUpdatePostMutation = (nid: number) => {
 
 const useDeletePostMutation = (nid: number) => {
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   return useMutation({
     mutationFn: () => deletePost(nid),
     onSuccess: () => {
+      router.push("/");
       queryClient.removeQueries(["post", nid]);
       queryClient.invalidateQueries(["posts"]);
     },
@@ -112,6 +114,9 @@ const useLikePostMutation = (nid: number) => {
     onError: (err, _, prev) => {
       queryClient.setQueryData<IPost | undefined>(["post", nid], prev);
     },
+    onSettled: () => {
+      queryClient.invalidateQueries(["post", nid]);
+    },
   });
 };
 
@@ -135,6 +140,9 @@ const useUnlikePostMutation = (nid: number) => {
     },
     onError: (err, _, prev) => {
       queryClient.setQueryData<IPost | undefined>(["post", nid], prev);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries(["post", nid]);
     },
   });
 };

--- a/src/hooks/query/series.ts
+++ b/src/hooks/query/series.ts
@@ -1,5 +1,8 @@
-import { useQuery } from "@tanstack/react-query";
-import { getSeriesAll } from "@/apis/series";
+import { useRouter } from "next/navigation";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ISeries, IUpdateSeriesInput } from "@/types";
+import { deleteSeries, getSeries, getSeriesAll, updateSeries } from "@/apis/series";
 
 const useGetSeriesQueries = () => {
   return useQuery({
@@ -8,4 +11,99 @@ const useGetSeriesQueries = () => {
   });
 };
 
-export { useGetSeriesQueries };
+const useGetSeriesQuery = (nid: number) => {
+  return useQuery({
+    queryKey: ["series", nid],
+    queryFn: () => getSeries(nid),
+  });
+};
+
+const useUpdateSeriesMutation = (nid: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: IUpdateSeriesInput) => updateSeries(nid, data),
+    onMutate: (data: IUpdateSeriesInput) => {
+      queryClient.cancelQueries(["series", nid]);
+
+      const previousSeries = queryClient.getQueryData<ISeries>(["series", nid]);
+
+      if (!previousSeries) return;
+
+      const previousSeriesList = queryClient.getQueryData<ISeries[]>(["series"]);
+
+      const newSeries: ISeries = { ...previousSeries, name: data.name, thumbnail: data.thumbnail };
+
+      queryClient.setQueryData<ISeries>(["series", nid], (prev) => {
+        if (!prev) return prev;
+
+        return newSeries;
+      });
+
+      queryClient.setQueryData<ISeries[]>(["series"], (prev) => {
+        if (!prev) return prev;
+
+        return prev.map((series) => {
+          if (series.nid !== nid) return series;
+
+          return newSeries;
+        });
+      });
+
+      return { previousSeries, previousSeriesList };
+    },
+    onError: (_, __, context) => {
+      if (!context) return;
+
+      const { previousSeries, previousSeriesList } = context;
+
+      queryClient.setQueryData<ISeries>(["series", nid], previousSeries);
+      queryClient.setQueryData<ISeries[]>(["series"], previousSeriesList);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries(["series", nid]);
+      queryClient.invalidateQueries(["series"]);
+    },
+  });
+};
+
+const useDeleteSeriesMutation = (nid: number) => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: () => deleteSeries(nid),
+    onMutate: () => {
+      queryClient.cancelQueries(["series", nid]);
+
+      const previousSeries = queryClient.getQueryData<ISeries>(["series", nid]);
+      const previousSeriesList = queryClient.getQueryData<ISeries[]>(["series"]);
+
+      queryClient.setQueryData<ISeries[]>(["series"], (prev) => {
+        if (!prev) return prev;
+
+        return prev.filter((series) => series.nid !== nid);
+      });
+
+      queryClient.removeQueries(["series", nid]);
+
+      return { previousSeries, previousSeriesList };
+    },
+    onError: (_, __, context) => {
+      if (!context) return;
+
+      const { previousSeries, previousSeriesList } = context;
+
+      queryClient.setQueryData<ISeries>(["series", nid], previousSeries);
+      queryClient.setQueryData<ISeries[]>(["series"], previousSeriesList);
+    },
+    onSettled: () => {
+      router.push("/series");
+
+      queryClient.invalidateQueries(["series", nid]);
+      queryClient.invalidateQueries(["series"]);
+    },
+  });
+};
+
+export { useGetSeriesQueries, useGetSeriesQuery, useUpdateSeriesMutation, useDeleteSeriesMutation };

--- a/src/types/series.ts
+++ b/src/types/series.ts
@@ -1,9 +1,14 @@
 import { IBaseResponse } from "@/types/base";
+import { IPost } from "@/types";
 
-interface ISeries extends IBaseResponse {
+interface IUpdateSeriesInput {
   name: string;
   thumbnail?: string;
+}
+
+interface ISeries extends IBaseResponse, IUpdateSeriesInput {
+  posts: IPost[];
   postCount: number;
 }
 
-export type { ISeries };
+export type { ISeries, IUpdateSeriesInput };


### PR DESCRIPTION

-  Closes #49

## ✨ **구현 기능 명세**
- 시리즈 페이지를 구현합니다.

## 🎁 **주목할 점**
- 상단에 시리즈 이름, 포함된 게시글 개수, 업데이트된 날짜가 존재합니다.
- 게시글 목록이 존재하면 무한 스크롤이 적용되어 있습니다.
- 정렬 버튼을 통해 오름차순, 내림차순으로 정렬할 수 있습니다.
- 로그인시 수정, 삭제 버튼을 통해 시리즈를 수정하거나 삭제할 수 있습니다.


## 🌄 **스크린샷**
![화면 기록 2023-09-16 오후 7 18 02](https://github.com/seoko97/SEOKO-client/assets/60173534/cf8395d7-fd33-4836-98ad-2f063d44c759)

